### PR TITLE
Changed Kramaa website link to a working one.

### DIFF
--- a/xdc-utility.php
+++ b/xdc-utility.php
@@ -380,7 +380,7 @@ include('inc/header.php') ?>
             </div>
             <h3>Kramaa <span>Testnet</span></h3>
             <div class="btn-block mb-1">
-            	<a href="https://www.kramaa.com" target="_blank"><button class="btn-hover color-1"><i class="fa fa-external-link"></i> Visit Website</button></a>
+            	<a href="https://web.archive.org/web/20200510121437if_/https://kramaa.com/" target="_blank"><button class="btn-hover color-1"><i class="fa fa-external-link"></i> Visit Website</button></a>
                 <a href="https://github.com/XinFinOrg/Kramaa" target="_blank"><button class="btn-hover color-3"><i class="fa fa-github"></i> Github</button></a>
             </div>
             <p>Kramaa is a Singapore based technology company converging latest technologies in blockchain, IoT, and analytics. The Company has created a blockchain based application ("The platform") for IoT identities linked to physical assets on XinFin's proven hybrid blockchain architecture.</p>


### PR DESCRIPTION
Kramaa.com is no longer online so the link does not work. The Wayback Machine
still has an archived copy. If we load this link using the if_ flag in the
URL, we can load the page without the Wayback Machine toolbar. This commit
replaces the kramaa.com link with the Wayback Machine link as described.